### PR TITLE
Removed fetchType.lazy from models

### DIFF
--- a/src/main/java/edu/fontys/horecarobot/databaselibrary/models/IngredientProduct.java
+++ b/src/main/java/edu/fontys/horecarobot/databaselibrary/models/IngredientProduct.java
@@ -28,7 +28,7 @@ public class IngredientProduct {
     @Type(type = "uuid-char")
     private UUID id;
 
-    @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "ingredient_id", insertable = false, updatable = false)
     private Ingredient ingredient;
 

--- a/src/main/java/edu/fontys/horecarobot/databaselibrary/models/Product.java
+++ b/src/main/java/edu/fontys/horecarobot/databaselibrary/models/Product.java
@@ -56,7 +56,7 @@ public class Product {
     )
     private List<Tag> tags = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "product_id")
     private List<IngredientProduct> ingredients;
 

--- a/src/main/java/edu/fontys/horecarobot/databaselibrary/models/RestaurantOrder.java
+++ b/src/main/java/edu/fontys/horecarobot/databaselibrary/models/RestaurantOrder.java
@@ -40,7 +40,7 @@ public class RestaurantOrder {
     @Column
     private Date created_at;
 
-    @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "table_id")
     private RestaurantTable table;
 


### PR DESCRIPTION
This fixes exceptions in spring boot. Currently, if we try to retrieve all orders spring boot gives us an exception that says that it can't convert the RestaurantTable model.